### PR TITLE
Update test matrix for new node versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,15 +19,11 @@ jobs:
         os: [ubuntu-20.04]
         # Don't forget to add all new flavors to this list!
         node: 
-          - "4"
-          - "5.6.0"
-          - "5"  # Introduced "cachedData"/"produceCachedData" after 5.7, need 5.10 for Buffer.from()
-          - "6"
-          - "8"
-          - "10"
           - "12"
           - "14"
           - "15"
+          - "16"
+          - "17"
     steps:
       # checkout code
       - uses: actions/checkout@v2


### PR DESCRIPTION
Drop everything that's EOLed; add up to and including node 17